### PR TITLE
Modify schema with lessons learned from mapping DFIR report

### DIFF
--- a/corpus/dfir_report_zero_to_domain_admin.json
+++ b/corpus/dfir_report_zero_to_domain_admin.json
@@ -2,131 +2,121 @@
     "$schema": "../schema/attack-flow-2021-11-03-draft.json",
     "flow": {
         "type": "attack-flow",
-        "id": "https://thedfirreport.com/2021/11/01/from-zero-to-domain-admin/",
+        "id": "flow://mitre.org/dfir-report-from-zero-to-domain-admin",
         "name": "The DFIR Report: ",
         "author": "Mark E. Haase <mhaase@mitre-engenuity.org>",
-        "created": "2021-11-08T11:57:00-05:00"
+        "created": "2021-11-08T11:57:00-05:00",
+        "sources": [
+            {
+                "name": "The DFIR Report: From Zero to Domain Admin",
+                "url": "https://thedfirreport.com/2021/11/01/from-zero-to-domain-admin/",
+                "publication_date": "2021-11-01"
+            }
+        ]
     },
     "actions": [
         {
             "id": "action://phishing",
             "name": "Phishing: Spearphishing Link",
             "description": "Phishing link to malicious Word Doc via Google Feed Proxy.",
-            "reference": "https://attack.mitre.org/techniques/T1566/002/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1566/002/"
         },
         {
             "id": "action://malicious-file",
             "name": "User Execution: Malicious File",
             "description": "Word document containing malicious macro.",
-            "reference": "https://attack.mitre.org/techniques/T1204/002/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1204/002/"
         },
         {
             "id": "action://macro",
             "name": "Command and Scripting Interpreter: Visual Basic",
             "description": "The macro downloads Hancitor DLL and runs it.",
-            "reference": "https://attack.mitre.org/techniques/T1059/005/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1059/005/"
         },
         {
             "id": "action://run-hancitor",
             "name": "Signed Binary Proxy Execution: Rundll32",
             "description": "Execute ier.dll (Hancitor).",
-            "reference": "https://attack.mitre.org/techniques/T1218/011/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1218/011/"
         },
         {
             "id": "action://hancitor-c2-beacon",
             "name": "Application Layer Protocol: Web Protocols",
             "description": "Hancitor uses HTTP protocol for C2.",
-            "reference": "https://attack.mitre.org/techniques/T1071/001/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1071/001/"
         },
         {
             "id": "action://process-injection",
             "name": "Process Injection",
             "description": "Process injection to run multiple scans and probes.",
-            "reference": "https://attack.mitre.org/techniques/T1055/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1055/"
         },
         {
             "id": "action://run-cor-dll",
             "name": "Signed Binary Proxy Execution: Rundll32",
             "description": "Execute cor.dll (Cobalt Strike stager).",
-            "reference": "https://attack.mitre.org/techniques/T1218/011/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1218/011/"
         },
         {
             "id": "action://cli-magic-number",
             "name": "Virtualization/Sandbox Evasion",
             "description": "Does not execute unless given a magic number argument.",
-            "reference": "https://attack.mitre.org/techniques/T1497/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1497/"
         },
         {
             "id": "action://run-agent-ps1",
             "name": "Command and Scripting Interpreter: Powershell",
             "description": "Execute agent1.ps1 to download and run beacon.",
-            "reference": "https://attack.mitre.org/techniques/T1059/001/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1059/001/"
         },
         {
             "id": "action://agent-ps1-base64",
             "name": "Obfuscated Files or Information",
             "description": "Powershell is base64-encoded.",
-            "reference": "https://attack.mitre.org/techniques/T1027/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1027/"
         },
         {
             "id": "action://agent-ps1-compile",
             "name": "Obfuscated Files or Information: Compile After Delivery",
             "description": "c# source code is compiled.",
-            "reference": "https://attack.mitre.org/techniques/T1027/004/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1027/004/"
         },
         {
             "id": "action://agent-ps1-beacon",
             "name": "Application Layer Protocol: Web Protocols",
             "description": "Agent.ps1 uses HTTP protocol for C2.",
-            "reference": "https://attack.mitre.org/techniques/T1071/001/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1071/001/"
         },
         {
             "id": "action://ingress-cobalt-strike",
             "name": "Ingress Tool Transfer",
             "description": "Download Cobalt Strike.",
-            "reference": "https://attack.mitre.org/techniques/T1105/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1105/"
         },
         {
             "id": "action://ingress-ficker",
             "name": "Ingress Tool Transfer",
             "description": "Download Ficker Stealer.",
-            "reference": "https://attack.mitre.org/techniques/T1105/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1105/"
         },
         {
             "id": "action://ficker-c2-beacon",
             "name": "Application Layer Protocol",
             "description": "Ficker beacon failed due to DNS resolution.",
             "reference": "https://attack.mitre.org/techniques/T1071/",
-            "logic_operator": "AND",
             "succeeded": 0
         },
         {
             "id": "action://scan-smb-backup",
             "name": "Network Service Scanning",
             "description": "Scan for SMB and backup products such as Synology.",
-            "reference": "https://attack.mitre.org/techniques/T1046/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1046/"
         },
         {
             "id": "action://enumerate-domain-accounts",
             "name": "Account Discovery: Domain Account",
             "description": "Enumerate domain administrator accounts.",
-            "reference": "https://attack.mitre.org/techniques/T1087/002/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1087/002/"
         },
         {
             "id": "action://enumerate-domain-groups",
@@ -139,50 +129,43 @@
             "id": "action://enumerate-smb-shares",
             "name": "Network Share Discovery",
             "description": "Search for c$ shares using discovered SMB.",
-            "reference": "https://attack.mitre.org/techniques/T1135/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1135/"
         },
         {
             "id": "action://lateral-tool-transfer",
             "name": "Lateral Tool Transfer",
             "description": "Copy cor.bat to \\\\${IP_ADDR}\\c$\\programdata.",
-            "reference": "https://attack.mitre.org/techniques/T1570/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1570/"
         },
         {
             "id": "action://zerologon-cve",
             "name": "Exploitation for Credential Access",
             "description": "Custom Zerologon (CVE-2020-1472) exploit to obtain domain administrator NTLM hash.",
-            "reference": "https://attack.mitre.org/techniques/T1212/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1212/"
         },
         {
             "id": "action://pass-the-hash",
             "name": "Use Alternate Authentication Material: Pass the Hash",
             "description": "PTH the domain administrator NTLM hash.",
-            "reference": "https://attack.mitre.org/techniques/T1550/002/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1550/002/"
         },
         {
             "id": "action://enumerate-machines",
             "name": "Command and Scripting Interpreter: Powershell",
             "description": "comp2.ps1 enumerates domain computers and stores in comps.txt.",
-            "reference": "https://attack.mitre.org/techniques/T1059/001/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1059/001/"
         },
         {
             "id": "action://discover-machines",
             "name": "Remote System Discovery",
             "description": "Discover domain copmputers using comps.txt.",
-            "reference": "https://attack.mitre.org/techniques/T1018/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1018/"
         },
         {
             "id": "action://scan-machines",
             "name": "Network Service Scanning",
             "description": "Check.exe pings machines in comps.txt and saves to check.txt.",
-            "reference": "https://attack.mitre.org/techniques/T1046/",
-            "logic_operator": "AND"
+            "reference": "https://attack.mitre.org/techniques/T1046/"
         }
     ],
     "assets": [

--- a/schema/attack-flow-2021-11-03-draft.json
+++ b/schema/attack-flow-2021-11-03-draft.json
@@ -15,9 +15,10 @@
                     "enum": ["attack-flow"]
                 },
                 "id": {
-                    "description": "The identifier for this Attack Flow. MUST be unique within this document. TODO: Ideally is unique among Attack Flows produced by a particular organization.",
+                    "description": "The identifier for this Attack Flow. MUST be unique within this document. MUST start with flow://. TODO: Ideally is unique among Attack Flows produced by a particular organization.",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "pattern": "^flow://.*"
                 },
                 "name": {
                     "description": "The name of the Attack Flow.",
@@ -35,6 +36,29 @@
                 "description": {
                     "description": "The description of the Attack Flow.",
                     "type": "string"
+                },
+                "sources": {
+                    "description": "Sources used to create this Attack Flow.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "description": "The name of the source.",
+                                "type": "string"
+                            },
+                            "url": {
+                                "description": "URL for source document.",
+                                "type": "string"
+                            },
+                            "publication_date": {
+                                "description": "Publication date of source document.",
+                                "type": "string",
+                                "format": "date"
+                            }
+                        },
+                        "required": ["name"]
+                    }
                 }
             },
             "required": [
@@ -53,7 +77,8 @@
                     "id": {
                         "description": "The identifier for this Action. MUST be unique within this document.",
                         "type": "string",
-                        "format": "uri"
+                        "format": "uri",
+                        "pattern": "^action://.*"
                     },
                     "type": {
                         "description": "Indicate that this is an Action",
@@ -95,7 +120,7 @@
                         "default": "AND"
                     }
                 },
-                "required": ["id", "name", "description", "logic_operator"]
+                "required": ["id", "name", "description"]
             }
         },
         "assets": {
@@ -105,9 +130,10 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "description": "The identifier for this Asset. MUST be unique within this document.",
+                        "description": "The identifier for this Asset. MUST be unique within this document. MUST start with asset://",
                         "type": "string",
-                        "format": "uri"
+                        "format": "uri",
+                        "pattern": "^asset://.*"
                     },
                     "type": {
                         "description": "Indicate that this is an Asset",
@@ -123,7 +149,7 @@
             }
         },
         "relationships": {
-            "description": "The list of relationship edges in the attack flow. All Actions MUST have a relationship to the flow.",
+            "description": "The list of relationship edges in the attack flow. See \"Relationships\" for permitted source and target object types.",
             "type": "array",
             "items": {
                 "type": "object",
@@ -131,7 +157,8 @@
                     "source": {
                         "description": "The source flow, action, or asset for this relationship.",
                         "type": "string",
-                        "format": "uri"
+                        "format": "uri",
+                        "pattern": "^(action|asset|flow|property)://.*"
                     },
                     "type": {
                         "description": "The type of relationship.",
@@ -139,8 +166,10 @@
                         "format": "uri"
                     },
                     "target": {
-                        "description": "The target asset, action, or property. If the target is an Action, the source MUST be an Asset. If the target is an Asset, the source MUST be an Action.",
-                        "type": "string"
+                        "description": "The target asset, action, or property.",
+                        "type": "string",
+                        "format": "uri",
+                        "pattern": "^(action|asset|flow|property)://.*"
                     }
                 },
                 "required": ["source", "type", "target"]

--- a/schema/attack-flow-example.json
+++ b/schema/attack-flow-example.json
@@ -2,14 +2,21 @@
     "$schema": "./attack-flow-2021-11-03-draft.json",
     "flow": {
         "type": "attack-flow",
-        "id": "id://flow-1",
+        "id": "flow://mitre.org/example",
         "name": "Attack Flow Example",
         "author": "Mark E. Haase <mhaase@mitre-engenuity.org>",
-        "created": "2021-10-13T12:20:02-05:00"
+        "created": "2021-10-13T12:20:02-05:00",
+        "sources": [
+            {
+                "name": "Example Source",
+                "url": "https://example.com/breach_report.html",
+                "publication_date": "2021-11-17"
+            }
+        ]
     },
     "actions": [
         {
-            "id": "id://action-1",
+            "id": "action://example-action-1",
             "type": "action",
             "name": "External Remote Services",
             "description": "Adversary accesses unsecured Kubernetes dashboard, gaining administrative console access.",
@@ -23,45 +30,45 @@
     ],
     "assets": [
         {
-            "id": "id://asset-1",
+            "id": "asset://example-asset-1",
             "type": "asset",
             "state": "compromised"
         },
         {
-            "id": "id://asset2",
+            "id": "asset://example-asset-2",
             "type": "asset",
             "state": "compromised"
         }
     ],
     "relationships": [
         {
-            "source": "id://action-1",
-            "type": "type://flow-v1#provides",
-            "target":  "asset-1"
+            "source": "asset://example-asset-1",
+            "type": "relationship://required-by",
+            "target":  "action://example-action-1"
         },
         {
-            "source": "id://asset-1",
-            "type": "type://flow-v1#required-by",
-            "target":  "action-1"
+            "source": "action://example-action-1",
+            "type": "relationship://provides",
+            "target":  "asset://example-asset-2"
         },
         {
-            "source": "id://action-1",
-            "type": "type://flow-v1#described-by",
-            "target":  "property-2"
+            "source": "action://example-action-1",
+            "type": "relationship://described-by",
+            "target":  "property://property-1"
         },
         {
-            "source": "id://ction-1",
-            "type": "type://flow-v1#described-by",
-            "target":  "property-1"
+            "source": "action://example-action-1",
+            "type": "relationship://described-by",
+            "target":  "property://property-2"
         },
         {
-            "source": "id://asset-1",
-            "type": "type://flow-v1#flow",
-            "target":  "flow-1"
+            "source": "asset://example-action-1",
+            "type": "relationship://flow",
+            "target":  "flow://mitre.org/example"
         }
     ],
     "properties": [
-        {"source":  "property-1", "type": "type://flow-v1#command", "target": "powershell.exe C:\\Users\\#{domain.admin.username}.#{domain}\\AppData\\Local\\takeScreenshot.ps1"},
-        {"source":  "property-2", "type":  "type://flow-v1#label", "target":  "cobalt strike"}
+        {"source":  "property-1", "type": "type://command", "target": "powershell.exe C:\\Users\\#{domain.admin.username}.#{domain}\\AppData\\Local\\takeScreenshot.ps1"},
+        {"source":  "property-2", "type":  "type://label", "target":  "cobalt strike"}
     ]
 }


### PR DESCRIPTION
Modify schema with lessons learned from mapping DFIR report

* Add sources section so that Attack Flow can reference external sources
    used to map out the Attack Flow.
* Remove logic_operator from required fields (it default to AND).
* Constrain the valid URIs for object IDs, e.g. asset://, action://,
    etc.
* Update example Attack Flow and DFIR Attack Flow to validate under new
    schema.