### PR TITLE
Add schema validation to CI/CD pipeline

### DIFF
--- a/schema/attack-flow-example.json
+++ b/schema/attack-flow-example.json
@@ -9,6 +9,7 @@
     },
     "actions": [
         {
+            "id": "id://action-1",
             "type": "action",
             "name": "External Remote Services",
             "description": "Adversary accesses unsecured Kubernetes dashboard, gaining administrative console access.",


### PR DESCRIPTION
When committing, validate the example Attack Flow and all flows in `corpus/`.