### PR TITLE
Add missing developer step in README (Fixes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements/requirements.txt
 pip install -r requirements/test-requirements.txt
+pip install -e .
 make
 ```
 


### PR DESCRIPTION
The developer documentation in `README.md` is missing a crucial step.