### PR TITLE
Fix flow metadata

### DIFF
--- a/src/attack_flow/graphviz.py
+++ b/src/attack_flow/graphviz.py
@@ -99,7 +99,7 @@ def _get_action_label(action):
     else:
         heading = "Action"
     description = "<br/>".join(
-        textwrap.wrap(label_escape(action.description), width=40)
+        textwrap.wrap(label_escape(action.get("description", "")), width=40)
     )
     confidence = confidence_num_to_label(action.get("confidence", 95))
     return "".join(

--- a/src/attack_flow/matrix.py
+++ b/src/attack_flow/matrix.py
@@ -64,11 +64,7 @@ def render(matrix_file, flow_bundle, out_file, show_control_points=False):
         try:
             tid = data["technique_id"]
         except KeyError:
-            logger.warning(
-                'Unable to find technique ID "%s" (is the graph missing node %s?)',
-                tid,
-                node,
-            )
+            logger.warning("Node (%s) does not have a technique ID.", node)
             continue
         if translation := technique_geometries.get(tid):
             technique_overlay = _create_technique_overlay(tid, translation)

--- a/src/attack_flow/mermaid.py
+++ b/src/attack_flow/mermaid.py
@@ -87,7 +87,7 @@ def convert(bundle):
             confidence = confidence_num_to_label(o.get("confidence", 95))
             label_lines = [
                 "<b>Action</b>",
-                f"<b>{name}</b>: {o.description}",
+                f"<b>{name}</b>: ", o.get("description", ""),
                 f"<b>Confidence</b> {confidence}",
             ]
             graph.add_node(o.id, "action", " - ".join(label_lines))

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -630,10 +630,13 @@ class AttackFlowPublisher extends DiagramPublisher {
                     if(prop.descriptor.form.type !== PropertyType.Dictionary) {
                         throw new Error(`'${ key }' is improperly defined.`);
                     }
-                    flow[key] = [];
+                    const extRefs = [];
                     for(let ref of prop.value.values()) {
                         let entries = ref.toRawValue() as RawEntries;
-                        flow[key].push(Object.fromEntries(entries));
+                        extRefs.push(Object.fromEntries(entries));
+                    }
+                    if (extRefs.length > 0) {
+                        flow[key] = extRefs;
                     }
                     break;
                 case "scope":

--- a/src/attack_flow_builder/src/assets/builder.config.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.ts
@@ -37,7 +37,7 @@ const config: AppConfiguration = {
                     author                       : {
                         type: PropertyType.Dictionary,
                         form: {
-                            name: { type: PropertyType.String, is_primary: true },
+                            name: { type: PropertyType.String, is_primary: true, is_required: true },
                             identity_class: {
                                 type: PropertyType.Enum,
                                 options: {

--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -1,12 +1,12 @@
 import { DiagramValidator } from "./scripts/DiagramValidator/DiagramValidator";
-import { 
-    DiagramObjectModel, 
-    DictionaryProperty, 
-    GraphObjectExport, 
-    ListProperty, 
-    Property, 
+import {
+    DiagramObjectModel,
+    DictionaryProperty,
+    GraphObjectExport,
+    ListProperty,
+    Property,
     PropertyType,
-    SemanticAnalyzer 
+    SemanticAnalyzer
 } from "./scripts/BlockDiagram";
 
 class AttackFlowValidator extends DiagramValidator {
@@ -18,10 +18,25 @@ class AttackFlowValidator extends DiagramValidator {
      */
     protected override validate(diagram: DiagramObjectModel): void {
         let graph = SemanticAnalyzer.toGraph(diagram);
+
         // Validate nodes
+        let actionNodeCount = 0;
+        let flowId;
         for (let [id, node] of graph.nodes) {
+            if (node.template.id == "flow") {
+                flowId = id;
+            }
+            if (node.template.id == "action") {
+                actionNodeCount++;
+            }
             this.validateNode(id, node);
         }
+
+        // The flow requires at least one start_ref, which means it must have at least one action node.
+        if (flowId && actionNodeCount == 0) {
+            this.addError(flowId, "The flow must have at least one action in it.");
+        }
+
         // Validate edges
         for (let [id, edge] of graph.edges) {
             this.validateEdge(id, edge);


### PR DESCRIPTION
- Instead of emitting an empty array for external references, don't emit that property at all.
- Throw a validation error if a flow does not have at least one action in it, since flows are required to have at least one start_ref.
- Make author name required.
- `af graphviz` / `af mermaid` should handle missing action description gracefully.
- Fix invalid warning message (trying to interpolate an undefined variable) in `af matrix` command.