### PR TITLE
Fix validation errors for network_traffic

### DIFF
--- a/src/attack_flow/mermaid.py
+++ b/src/attack_flow/mermaid.py
@@ -40,7 +40,7 @@ class MermaidGraph:
 
         lines.append("")
 
-        for (node_id, node_class, label) in self.nodes:
+        for node_id, node_class, label in self.nodes:
             node_id = convert_id(node_id)
             label = "<br>".join(textwrap.wrap(label.replace('"', ""), width=40))
             if self.classes[node_class][0] == "circle":
@@ -87,7 +87,8 @@ def convert(bundle):
             confidence = confidence_num_to_label(o.get("confidence", 95))
             label_lines = [
                 "<b>Action</b>",
-                f"<b>{name}</b>: ", o.get("description", ""),
+                f"<b>{name}</b>: ",
+                o.get("description", ""),
                 f"<b>Confidence</b> {confidence}",
             ]
             graph.add_node(o.id, "action", " - ".join(label_lines))

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -351,7 +351,7 @@ class AttackFlowPublisher extends DiagramPublisher {
                 case "domain-name":
                     // Network traffic is a special case where it's _parent_ can be embedded if its one of the
                     // above types.
-                    if (c.obj.type == "network-traffic") {
+                    if (c.obj.type === "network-traffic") {
                         sro = this.tryEmbedInNetworkTraffic(parent, c.obj);
                     } else {
                         sro = this.tryEmbedInDefault(parent, c.obj);
@@ -504,9 +504,9 @@ class AttackFlowPublisher extends DiagramPublisher {
      *  An SRO, if one was created.
      */
     private tryEmbedInNetworkTraffic(parent: Sdo, child: Sdo): Sro | undefined {
-        if (parent.type == "network-traffic" && !parent["dst_ref"]) {
+        if (parent.type === "network-traffic" && !parent["dst_ref"]) {
             parent["dst_ref"] = child.id;
-        } else if (child.type == "network-traffic" && !child["src_ref"]) {
+        } else if (child.type === "network-traffic" && !child["src_ref"]) {
             child["src_ref"] = parent.id;
         } else {
             return this.createSro(parent, child);

--- a/src/attack_flow_builder/src/assets/builder.config.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.ts
@@ -676,7 +676,7 @@ const config: AppConfiguration = {
                     is_active                    : BoolEnum,
                     src_port                     : { type: PropertyType.Int, min: 0, max: 65535 },
                     dst_port                     : { type: PropertyType.Int, min: 0, max: 65535 },
-                    protocols                    : { type: PropertyType.List, form: { type: PropertyType.String, is_required: true }},
+                    protocols                    : { type: PropertyType.List, min_items: 1, form: { type: PropertyType.String, is_required: true }},
                     src_byte_count               : { type: PropertyType.Int, min: 0 },
                     dst_byte_count               : { type: PropertyType.Int, min: 0 },
                     src_packets                  : { type: PropertyType.Int, min: 0 },

--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -25,17 +25,17 @@ class AttackFlowValidator extends DiagramValidator {
         let actionNodeCount = 0;
         let flowId;
         for (let [id, node] of this.graph.nodes) {
-            if (node.template.id == "flow") {
+            if (node.template.id === "flow") {
                 flowId = id;
             }
-            if (node.template.id == "action") {
+            if (node.template.id === "action") {
                 actionNodeCount++;
             }
             this.validateNode(id, node);
         }
 
         // The flow requires at least one start_ref, which means it must have at least one action node.
-        if (flowId && actionNodeCount == 0) {
+        if (flowId && actionNodeCount === 0) {
             this.addError(flowId, "The flow must have at least one action in it.");
         }
 
@@ -172,7 +172,7 @@ class AttackFlowValidator extends DiagramValidator {
                 if(property instanceof ListProperty) {
                     let descriptor = property.descriptor as any;
                     if (descriptor.min_items != null && property.value.size < descriptor.min_items) {
-                        const suffix = descriptor.min_items == 1 ? "" : "s";
+                        const suffix = descriptor.min_items === 1 ? "" : "s";
                         this.addError(id, `${name}: Requires at least ${descriptor.min_items} item${suffix}`);
                     }
                     for(let v of property.value.values()) {

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/PropertyDescriptorTypes.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/PropertyDescriptorTypes.ts
@@ -86,6 +86,7 @@ export type ListPropertyDescriptor = {
     type: PropertyType.List,
     form: PropertyDescriptor
     value?: any,
+    min_items?: number,
     is_primary?: boolean,
     is_visible?: boolean,
     is_editable? : boolean
@@ -152,6 +153,7 @@ type ValueListDescriptor = {
     type: PropertyType.List,
     form: ValueDescriptor,
     value?: any,
+    min_items?: number,
     is_primary?: boolean,
     is_visible?: boolean,
     is_editable? : boolean

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -92,7 +92,7 @@ def test_graph_is_missing_node(caplog):
         )
 
     assert (
-        "is the graph missing node attack-action--7976c9b3-b593-45b6-a66e-3a49bfc1008f?"
+        "Node (attack-action--7976c9b3-b593-45b6-a66e-3a49bfc1008f) does not have a technique ID."
         in caplog.text
     )
 

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -14,13 +14,13 @@ def test_convert_attack_flow_to_mermaid():
             classDef condition fill:#99ff99
             classDef builtin fill:#cccccc
 
-            attack_action__52f2c35a_fa2a_45a4_b84c_46ad9498071f["<b>Action</b> - <b>T1 Action 1</b>:<br>Description of action 1 -<br><b>Confidence</b> Very Probable"]
+            attack_action__52f2c35a_fa2a_45a4_b84c_46ad9498071f["<b>Action</b> - <b>T1 Action 1</b>:  -<br>Description of action 1 -<br><b>Confidence</b> Very Probable"]
             class attack_action__52f2c35a_fa2a_45a4_b84c_46ad9498071f action
-            attack_action__dd3820fa_bae3_4270_8000_5c4642fa780c["<b>Action</b> - <b>Action 2</b>:<br>Description of action 2 -<br><b>Confidence</b> Very Probable"]
+            attack_action__dd3820fa_bae3_4270_8000_5c4642fa780c["<b>Action</b> - <b>Action 2</b>:  -<br>Description of action 2 -<br><b>Confidence</b> Very Probable"]
             class attack_action__dd3820fa_bae3_4270_8000_5c4642fa780c action
-            attack_action__a0847849_a533_4b1f_a94a_720bbd25fc17["<b>Action</b> - <b>T3 Action 3</b>:<br>Description of action 3 -<br><b>Confidence</b> Very Probable"]
+            attack_action__a0847849_a533_4b1f_a94a_720bbd25fc17["<b>Action</b> - <b>T3 Action 3</b>:  -<br>Description of action 3 -<br><b>Confidence</b> Very Probable"]
             class attack_action__a0847849_a533_4b1f_a94a_720bbd25fc17 action
-            attack_action__7ddab166_c83e_4c79_a701_a0dc2a905dd3["<b>Action</b> - <b>T4 Action 4</b>:<br>Description of action 4 -<br><b>Confidence</b> Very Probable"]
+            attack_action__7ddab166_c83e_4c79_a701_a0dc2a905dd3["<b>Action</b> - <b>T4 Action 4</b>:  -<br>Description of action 4 -<br><b>Confidence</b> Very Probable"]
             class attack_action__7ddab166_c83e_4c79_a701_a0dc2a905dd3 action
             attack_condition__64d5bf0b_6acc_4f43_b0f2_aa93a219897a["<b>Condition:</b> My condition"]
             class attack_condition__64d5bf0b_6acc_4f43_b0f2_aa93a219897a condition


### PR DESCRIPTION
- `protocols` requires at least one item in the list
- network traffic must have either a src_ref or a dst_ref, which in turn must be an IP, MAC, or domain name node

The latter point is rather complicated, because it needs to be handled at both the validator and publisher level, and it means that a network traffic's parent can be embedded in the network traffic if the parent has the proper type.