### PR TITLE
AF-125 regex windows registry

### DIFF
--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -11,6 +11,8 @@ import {
 
 class AttackFlowValidator extends DiagramValidator {
 
+    static WindowsRegistryregex = /^(?:(HKLM)|(HKEY_LOCAL_MACHINE)|(HKCC)|(HKEY_CURRENT_CONFIG)|(HKCR)|(HKEY_CLASSES_ROOT)|(HKCU)|(HKEY_CURRENT_USER)|(HKU)|(HKEY_USERS))/i
+
     /**
      * Validates a diagram.
      * @param diagram
@@ -54,6 +56,29 @@ class AttackFlowValidator extends DiagramValidator {
         // Validate properties
         for (const [key, value] of node.props.value) {
             this.validateProperty(id, key, value)
+
+            //window.alert(node.template.id);
+            // windows_registry_key
+            // Additional validation for windows registry keys
+            if(node.template.id == "windows_registry_key") {
+                //window.alert(value);
+                /*
+                properties: {
+                    key                          : { type: PropertyType.String, is_primary: true },
+                    values                       : { type: PropertyType.List, form: { type: PropertyType.String }},
+                    modified_time                : { type: PropertyType.Date },
+                    number_of_subkeys            : { type: PropertyType.Int, min: 0 },
+                },
+                */
+               
+                switch(key) {
+                    case "key":
+                        if(!AttackFlowValidator.WindowsRegistryregex.test(String(value))) {
+                            this.addError(id, "Invalid Windows registry key.");
+                        }
+                }
+                console.log(key + " : " + value);
+            }
         }
         // Validate links
         switch(node.template.id) {

--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -68,6 +68,7 @@ class AttackFlowValidator extends DiagramValidator {
                 if (!AttackFlowValidator.WindowsRegistryregex.test(String(node.props.value.get("key")))) {
                     this.addError(id, "Invalid Windows registry key.");
                 }
+                break;
         }
     }
 

--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -11,7 +11,7 @@ import {
 
 class AttackFlowValidator extends DiagramValidator {
 
-    static WindowsRegistryregex = /^(?:(HKLM)|(HKEY_LOCAL_MACHINE)|(HKCC)|(HKEY_CURRENT_CONFIG)|(HKCR)|(HKEY_CLASSES_ROOT)|(HKCU)|(HKEY_CURRENT_USER)|(HKU)|(HKEY_USERS))/i
+    static WindowsRegistryregex = /^(Computer\\)?((HKEY_LOCAL_MACHINE)|(HKEY_CURRENT_CONFIG)|(HKEY_CLASSES_ROOT)|(HKEY_CURRENT_USER)|(HKEY_YSERS))\\(.*)[^\\]/
 
     /**
      * Validates a diagram.
@@ -56,29 +56,6 @@ class AttackFlowValidator extends DiagramValidator {
         // Validate properties
         for (const [key, value] of node.props.value) {
             this.validateProperty(id, key, value)
-
-            //window.alert(node.template.id);
-            // windows_registry_key
-            // Additional validation for windows registry keys
-            if(node.template.id == "windows_registry_key") {
-                //window.alert(value);
-                /*
-                properties: {
-                    key                          : { type: PropertyType.String, is_primary: true },
-                    values                       : { type: PropertyType.List, form: { type: PropertyType.String }},
-                    modified_time                : { type: PropertyType.Date },
-                    number_of_subkeys            : { type: PropertyType.Int, min: 0 },
-                },
-                */
-               
-                switch(key) {
-                    case "key":
-                        if(!AttackFlowValidator.WindowsRegistryregex.test(String(value))) {
-                            this.addError(id, "Invalid Windows registry key.");
-                        }
-                }
-                console.log(key + " : " + value);
-            }
         }
         // Validate links
         switch(node.template.id) {
@@ -87,6 +64,10 @@ class AttackFlowValidator extends DiagramValidator {
                     this.addError(id, "A Note must point to at least one object.");
                 }
                 break;
+            case "windows_registry_key": // Additional validation for windows registry keys
+                if (!AttackFlowValidator.WindowsRegistryregex.test(String(node.props.value.get("key")))) {
+                    this.addError(id, "Invalid Windows registry key.");
+                }
         }
     }
 


### PR DESCRIPTION
Following rules listed on STIX's windows-registry-key: https://docs.oasis-open.org/cti/stix/v2.1/cs01/stix-v2.1-cs01.html#_luvw8wjlfo3y. Also I see the _Values_ property of the Windows Registry Key object is simply a list of strings rather than a STIX windows-registry-value-type (from same link above). For this reason I don't do any regex validation on they _Values_ list since I'm assuming it is the value (which can be anything) that was modified.

See notes in PR #78 for clarification on why Windows registry regex check is in the _Validate links_ section of `validateNode()`.