### PR TITLE
AF-156 Hide Tactic+Technique References from Flow

### DIFF
--- a/src/attack_flow_builder/src/assets/builder.config.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.ts
@@ -82,7 +82,7 @@ const config: AppConfiguration = {
                             }
                         }
                     },
-                    created                      : { type: PropertyType.Date, value: new Date(), is_visible: false }
+                    created                      : { type: PropertyType.Date, value: new Date(), is_visible_chart: false, is_visible_sidebar: false }
                 },
                 style: DarkTheme.Page()
             },
@@ -116,9 +116,9 @@ const config: AppConfiguration = {
                 properties: {
                     name                         : { type: PropertyType.String, is_primary: true, is_required: true },
                     tactic_id                    : { type: PropertyType.String },
-                    tactic_ref                   : { type: PropertyType.String },
+                    tactic_ref                   : { type: PropertyType.String, is_visible_chart: false, is_visible_sidebar: true },
                     technique_id                 : { type: PropertyType.String },
-                    technique_ref                : { type: PropertyType.String },
+                    technique_ref                : { type: PropertyType.String, is_visible_chart: false, is_visible_sidebar: true },
                     description                  : { type: PropertyType.String },
                     confidence                   : {
                         type: PropertyType.Enum,
@@ -196,7 +196,8 @@ const config: AppConfiguration = {
                         type: PropertyType.String,
                         value: "OR",
                         is_primary: true,
-                        is_visible: false,
+                        is_visible_chart: false,
+                        is_visible_sidebar: false,
                         is_editable: false,
                     }
                 },
@@ -213,7 +214,8 @@ const config: AppConfiguration = {
                         type: PropertyType.String,
                         value: "AND",
                         is_primary: true,
-                        is_visible: false,
+                        is_visible_chart: false,
+                        is_visible_sidebar: false,
                         is_editable: false,
                     }
                 },

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/DiagramModelTypes/BranchBlockModel.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/DiagramModelTypes/BranchBlockModel.ts
@@ -259,7 +259,7 @@ export class BranchBlockModel extends DiagramObjectModel {
                         continue;
 
                     // Ignore hidden fields 
-                    if(!(value.descriptor.is_visible ?? true))
+                    if(!(value.descriptor.is_visible_chart ?? true))
                         continue;
                     
                     // Ignore the primary key
@@ -402,7 +402,7 @@ export class BranchBlockModel extends DiagramObjectModel {
         for(let [key, value] of this.props.value) {
             if(key === this.props.primaryKey)
                 continue;
-            if(!(value.descriptor.is_visible ?? true))
+            if(!(value.descriptor.is_visible_chart ?? true))
                 continue;
             if(value.isDefined())
                 return true;

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/DiagramModelTypes/DictionaryBlockModel.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/DiagramModelTypes/DictionaryBlockModel.ts
@@ -236,7 +236,7 @@ export class DictionaryBlockModel extends DiagramObjectModel {
                         continue;
 
                     // Ignore hidden fields 
-                    if(!(value.descriptor.is_visible ?? true))
+                    if(!(value.descriptor.is_visible_chart ?? true))
                         continue;
                     
                     // Ignore the primary key
@@ -337,7 +337,7 @@ export class DictionaryBlockModel extends DiagramObjectModel {
         for(let [key, value] of this.props.value) {
             if(key === this.props.primaryKey)
                 continue;
-            if(!(value.descriptor.is_visible ?? true))
+            if(!(value.descriptor.is_visible_chart ?? true))
                 continue;
             if(value.isDefined())
                 return true;

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/PropertyDescriptorTypes.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/PropertyDescriptorTypes.ts
@@ -7,7 +7,8 @@ type ValueDescriptorBase<K extends ValueTypes> = {
     type: K,
     value?: ValueTypeScriptType[K]
     is_primary?: boolean,
-    is_visible?: boolean
+    is_visible_chart?: boolean,
+    is_visible_sidebar?: boolean,
     is_editable? : boolean,
     is_required? : boolean,
 }
@@ -87,7 +88,8 @@ export type ListPropertyDescriptor = {
     form: PropertyDescriptor
     value?: any,
     is_primary?: boolean,
-    is_visible?: boolean,
+    is_visible_chart?: boolean,
+    is_visible_sidebar?: boolean,
     is_editable? : boolean
 }
 
@@ -97,7 +99,8 @@ export type DictionaryPropertyDescriptor = {
         [key: string]: PropertyDescriptor
     },
     is_primary?: boolean,
-    is_visible?: boolean,
+    is_visible_chart?: boolean,
+    is_visible_sidebar?: boolean,
 }
 
 export type ListValue
@@ -133,7 +136,8 @@ type ValueDictionaryListDescriptor = {
     form: ValueDictionaryDescriptor,
     value?: any,
     is_primary?: boolean,
-    is_visible?: boolean,
+    is_visible_chart?: boolean,
+    is_visible_sidebar?: boolean,
     is_editable? : boolean
 }
 
@@ -145,7 +149,8 @@ type ValueDictionaryDescriptor = {
             | ValueListDescriptor
     },
     is_primary?: boolean,
-    is_visible?: boolean,
+    is_visible_chart?: boolean,
+    is_visible_sidebar?: boolean,
 }
 
 type ValueListDescriptor = {
@@ -153,7 +158,8 @@ type ValueListDescriptor = {
     form: ValueDescriptor,
     value?: any,
     is_primary?: boolean,
-    is_visible?: boolean,
+    is_visible_chart?: boolean,
+    is_visible_sidebar?: boolean,
     is_editable? : boolean
 }
 

--- a/src/attack_flow_builder/src/components/Controls/Fields/DictionaryField.vue
+++ b/src/attack_flow_builder/src/components/Controls/Fields/DictionaryField.vue
@@ -63,7 +63,7 @@ export default defineComponent({
      */
     hasVisibleProperties(): boolean {
       for(let value of this._property.value.values()) {
-        if(value.descriptor.is_visible ?? true)
+        if(value.descriptor.is_visible_chart ?? true)
           return true;
       }
       return false;

--- a/src/attack_flow_builder/src/components/Controls/Fields/DictionaryField.vue
+++ b/src/attack_flow_builder/src/components/Controls/Fields/DictionaryField.vue
@@ -63,7 +63,7 @@ export default defineComponent({
      */
     hasVisibleProperties(): boolean {
       for(let value of this._property.value.values()) {
-        if(value.descriptor.is_visible_chart ?? true)
+        if(value.descriptor.is_visible_sidebar ?? true)
           return true;
       }
       return false;

--- a/src/attack_flow_builder/src/components/Controls/Fields/DictionaryFieldContents.vue
+++ b/src/attack_flow_builder/src/components/Controls/Fields/DictionaryFieldContents.vue
@@ -45,7 +45,7 @@ export default defineComponent({
      */
     fields(): [string, Property][] {
       return [...this.property.value.entries()].filter(
-        o => o[1].descriptor.is_visible ?? true
+        o => o[1].descriptor.is_visible_sidebar ?? true
       );
     }
 

--- a/src/attack_flow_builder/src/components/Elements/PropertyEditor.vue
+++ b/src/attack_flow_builder/src/components/Elements/PropertyEditor.vue
@@ -61,7 +61,7 @@ export default defineComponent({
         return false;
       }
       for(let value of this.property.value.values()) {
-        if(value.descriptor.is_visible ?? true)
+        if(value.descriptor.is_visible_sidebar ?? true)
           return true;
       }
       return false;


### PR DESCRIPTION
Currently works, but before merging I want to review the interaction of the diagram model typescript files and the vue components to ensure everything is being verified correctly. _is_visible_ has been split to _is_visible_chart_ and _is_visible_sidebar_ to denote whether a property should be visible on the chart's node and/or property-editor sidebar.

Property declarations were updated in _builder.config.ts_ to setup the schema, blocking the tactic+technique references from rendering on the chart while still being viewable/editable in the sidebar.

A couple discussion points I'd like to chat about pre-merge:

1. _BranchBlockModel.ts_ and _DictionaryBlockModel.ts_ were both updated. For checking the visibility of these fields, I used _is_visible_chart_ since this seemed to lay out the boilerplate which the vue-component would later use to populate the chart's/diagram's UI node with properties. Is this the right thinking?
2. _DictionaryField.vue_ vs _DictionaryFieldContents.vue_. How do each of these handle the rendering individual nodes to the screen? I was surprised to find success when verifying visibility with _is_visible_chart_ with _DictionaryField.vue_, but _is_visible_sidebar_ with _DictionaryFieldContents.vue_. I would think both of these would want to use _is_visible_chart_, but that wasn't the case.
3. Property editor component (_PropertyEditor.vue_) verifies visibility using _is_visible_sidebar_, but the behavior didn't change when verifying with _is_visible_chart_. This should've technically made the _technique_ref_ and _tactic_ref_ disappear from the property editor sidebar, unless this is a change that needs to be made in _EditorSidebar.vue_. I swayed away from modifying _EditorSidebar.vue_ for now since this didn't do any visibility checking previously; my "first pass" at this ticket was to transition existing _is_visible_ calls to the new sidebar+chart solution. In summary, what is the relationship of _PropertyEditor.vue_ vs _EditorSidebar.vue_?