### PR TITLE
AF-122 Start Refs

### DIFF
--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -666,7 +666,7 @@ class AttackFlowPublisher extends DiagramPublisher {
         for (const [parentId, parentNode] of graph.nodes) {
             // Ignore nodes that are not actions or conditions.
             const parentType = parentNode.template.id;
-            if (parentType != "action" && parentType != "condition") {
+            if (parentType !== "action" && parentType !== "condition") {
                 continue;
             }
             const edges: string[] = [];
@@ -690,7 +690,7 @@ class AttackFlowPublisher extends DiagramPublisher {
                 const descendantNode = graph.nodes.get(descendantId);
                 if (descendantNode) {
                     const descendantType = descendantNode.template.id;
-                    if (descendantType == "action" || descendantType == "condition") {
+                    if (descendantType === "action" || descendantType === "condition") {
                         edges.push(descendantId);
                     } else {
                         stack.push(...getChildNodes(descendantId));


### PR DESCRIPTION
Update the logic for start refs:
  1. impute the graph containing only action and condition nodes
  2. any node in the imputed graph with in-degree equal to zero is a start ref

Note that cycles in the graph are undefined behavior -- it throws an exception right now to prevent creating an invalid Attack Flow -- but we may need to revisit this in the future depending on how common this is in practice.