### PR TITLE
AF-142 Limit File Picker to Configured File Extension

### DIFF
--- a/src/attack_flow_builder/src/assets/scripts/Browser.ts
+++ b/src/attack_flow_builder/src/assets/scripts/Browser.ts
@@ -57,14 +57,19 @@ export class Browser {
     
     /**
      * Prompts the user to select a text file from their file system.
+     * @param fileTypes
+     *  The file dialog's accepted file types.
      * @returns
      *  A Promise that resolves with the chosen text file.
      */
-    public static openTextFileDialog(): Promise<TextFile> {
+    public static openTextFileDialog(...fileTypes: string[]): Promise<TextFile> {
             
         // Create file input
         let fileInput = document.createElement("input");
         fileInput.type = "file";
+        if(0 < fileTypes.length) {
+            fileInput.accept = fileTypes.map(o => `.${o}`).join(",");
+        }
         
         // Configure file input
         let result = new Promise<TextFile>((resolve) => {

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
@@ -60,7 +60,8 @@ export class LoadFile extends AppCommand {
      *  The {@link LoadFile} command.
      */
     public static async fromFileSystem(context: ApplicationStore): Promise<LoadFile> {
-        let file = (await Browser.openTextFileDialog()).contents as string;
+        let ext = Configuration.file_type_extension;
+        let file = (await Browser.openTextFileDialog(ext)).contents as string;
         let page = await PageEditor.fromFile(file);
         return new LoadFile(context, page);
     }


### PR DESCRIPTION
File selection now (generally) limits the set of selectable files to files with the application's configured file extension.