### PR TITLE
Af149 opinion

### DIFF
--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -259,7 +259,6 @@ class AttackFlowPublisher extends DiagramPublisher {
                 case PropertyType.Enum:
                     if (prop instanceof EnumProperty && prop.isDefined()) {
                         let value = prop.toReferenceValue()!.toRawValue()!;
-                        console.log(value);
                         if(["True", "False"].includes(value.toString())) {
                             // case(BoolEnum)
                             node[key] = value === "True";

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -223,15 +223,13 @@ class AttackFlowPublisher extends DiagramPublisher {
                     throw new Error("Basic dictionaries cannot contain dictionaries.");
                 case PropertyType.Enum:
                     if (prop instanceof EnumProperty && prop.isDefined()) {
-                        let value = prop.toReferenceValue()!.toRawValue()!;
-                        if(["True", "False"].includes(value.toString())) {
+                        let value = prop.toRawValue()!;
+                        if(["true", "false"].includes(value.toString())) {
                             // case(BoolEnum)
-                            node[key] = value === "True";
+                            node[key] = value === "true";
                         }
                         else {
                             // case(String | List | Dictionary | null)
-                            value = value.toString();
-                            value = value.toLowerCase().replace(' ', '-');
                             node[key] = value;
                         }
                     }

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -259,7 +259,17 @@ class AttackFlowPublisher extends DiagramPublisher {
                 case PropertyType.Enum:
                     if (prop instanceof EnumProperty && prop.isDefined()) {
                         let value = prop.toReferenceValue()!.toRawValue()!;
-                        node[key] = value === "True";
+                        console.log(value);
+                        if(["True", "False"].includes(value.toString())) {
+                            // case(BoolEnum)
+                            node[key] = value === "True";
+                        }
+                        else {
+                            // case(String | List | Dictionary | null)
+                            value = value.toString();
+                            value = value.toLowerCase().replace(' ', '-');
+                            node[key] = value;
+                        }
                     }
                     break;
                 case PropertyType.List:
@@ -346,6 +356,9 @@ class AttackFlowPublisher extends DiagramPublisher {
                     sro = this.tryEmbedInOperator(parent, c.obj);
                     break;
                 case "note":
+                    this.tryEmbedInNote(parent, c.obj);
+                    break;
+                case "opinion":
                     this.tryEmbedInNote(parent, c.obj);
                     break;
                 default:

--- a/src/attack_flow_builder/src/assets/builder.config.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.ts
@@ -446,7 +446,21 @@ const config: AppConfiguration = {
                 properties: {
                     explanation                  : { type: PropertyType.String, is_primary: true },
                     authors                      : { type: PropertyType.List, form: { type: PropertyType.String } },
-                    opinion                      : { type: PropertyType.String, is_required: true },
+                    opinion                      : {
+                        type: PropertyType.Enum,
+                        options: {
+                            type: PropertyType.List,
+                            form: { type: PropertyType.String },
+                            value: [
+                                ["strongly-disagree", "Strongly Disagree"],
+                                ["disagree", "Disagree"],
+                                ["neutral", "Neutral"],
+                                ["agree", "Agree"],
+                                ["strongly-agree", "Strongly Agree"]
+                            ]
+                        },
+                        is_required: true
+                    }
                 },
                 anchor_template: "@__builtin__anchor",
                 style: DarkTheme.DictionaryBlock({ head: { ...Colors.Gray }})

--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -62,6 +62,11 @@ class AttackFlowValidator extends DiagramValidator {
                     this.addError(id, "A Note must point to at least one object.");
                 }
                 break;
+            case "opinion":
+                if(node.next.length === 0) {
+                    this.addError(id, "An Opinion must point to at least one object.");
+                }
+                break;
         }
     }
 

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/ListProperty.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/ListProperty.ts
@@ -46,7 +46,7 @@ export class ListProperty extends CollectionProperty {
                     // Create property
                     let prop = Property.create(this, descriptor.form, value);
                     // Add property
-                    this.value.set(MD5(id), prop);
+                    this.value.set(id, prop);
                 }
             } else {
                 for(let id in descriptor.value) {
@@ -54,7 +54,7 @@ export class ListProperty extends CollectionProperty {
                     let value = descriptor.value[id];
                     let prop = Property.create(this, descriptor.form, value);
                     // Add property
-                    this.value.set(MD5(id), prop);
+                    this.value.set(id, prop);
                 }
             }
         }


### PR DESCRIPTION
Got stuck for a while trying to over-engineer the publisher, only to realize it was best to keep it simple and build on it later.
The main concern is when an object that uses an Enum value is published,  the node as as they appear in the builder. i.e.  if we wanted to make an enumeration such as:
`value: [    ['internal_use_only': 'external_use_only']   ]`
The node would hold `value: 'external_use_only'` rather than `value: 'internal_use_only'` in order to correctly assign a value within the schema of the object. At this moment, we don't have any object whose 'internal' and 'external' enumeration values differ, so keeping it simple for now.

Changes:

- blocked publishing until an object ref is assigned to an Opinion object
- added the required 'object_refs' in the publisher