### PR TITLE
Small changes

### DIFF
--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -363,6 +363,9 @@ class AttackFlowPublisher extends DiagramPublisher {
                 case "note":
                     this.tryEmbedInNote(parent, c.obj);
                     break;
+                case "report":
+                    this.tryEmbedInNote(parent, c.obj);
+                    break;
                 default:
                     sro = this.tryEmbedInDefault(parent, c.obj);
             }

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -357,6 +357,9 @@ class AttackFlowPublisher extends DiagramPublisher {
                         sro = this.tryEmbedInDefault(parent, c.obj);
                     }
                     break;
+                case "grouping":
+                    this.tryEmbedInNote(parent, c.obj);
+                    break;
                 case "network-traffic":
                     sro = this.tryEmbedInNetworkTraffic(parent, c.obj);
                     break;

--- a/src/attack_flow_builder/src/assets/builder.config.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.ts
@@ -538,7 +538,7 @@ const config: AppConfiguration = {
                 type: TemplateType.DictionaryBlock,
                 role: SemanticRole.Node,
                 properties: {
-                    number                       : { type: PropertyType.String, is_primary: true, is_required: true },
+                    number                       : { type: PropertyType.Int, is_primary: true, is_required: true },
                     name                         : { type: PropertyType.String },
                     rir                          : { type: PropertyType.String },
                 },

--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -151,6 +151,11 @@ class AttackFlowValidator extends DiagramValidator {
                     this.addError(id, "A Note must point to at least one object.");
                 }
                 break;
+            case "report":
+                if(node.next.length === 0) {
+                    this.addError(id, "A Report must point to at least one object.");
+                }
+                break;
             case "windows_registry_key": // Additional validation for windows registry keys
                 if (!AttackFlowValidator.WindowsRegistryregex.test(String(node.props.value.get("key")))) {
                     this.addError(id, "Invalid Windows registry key.");

--- a/src/attack_flow_builder/src/assets/builder.config.validator.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.validator.ts
@@ -143,6 +143,11 @@ class AttackFlowValidator extends DiagramValidator {
         }
         // Validate links
         switch(node.template.id) {
+            case "grouping":
+                if(node.next.length === 0) {
+                    this.addError(id, "A Grouping must point to at least one object.");
+                }
+            break;
             case "network_traffic":
                 this.validateNetworkTrafficLinks(id, node);
                 break;


### PR DESCRIPTION
This branch was created to tackle some small tickets that did not take enough work to justify multiple branches. Main work consists of adding cases for attaching object refs, and associated validation warnings.

Tickets encapsulated:
- [x] AF-164: Report
       - publishing with object references
       - validator warning to block publishing without object references
- [ ] AF-165: Observed data (in-progress for restricting type of attached object)
       - publishing with object references
       - validator warning to block publishing without object references
       remaining task:
              - validator blocking for incorrect attached object type (must be of type `observable`
- [x] AF-167: Autonomous system
       - small fix to publish with incorrect type for `number`
- [x] AF-169: Grouping
       - publishing with object references
       - validator warning to block publishing without object references