### PR TITLE
AF-26 Autosave

### DIFF
--- a/src/attack_flow_builder/src/components/Elements/BlockDiagram.vue
+++ b/src/attack_flow_builder/src/components/Elements/BlockDiagram.vue
@@ -267,7 +267,7 @@ export default defineComponent({
      */
     onCanvasClick(e: PointerEvent, x: number, y: number) {
       this.execute(new Page.UnselectDescendants(this.editor.page));
-      this.execute(new App.SetEditorPointerLocation(this.ctx, this.editor.id, x, y));
+      this.execute(new App.SetEditorPointerLocation(this.ctx, x, y));
       if (e.button === MouseClick.Right) {
         this.openContextMenu(x, y);
       }
@@ -366,7 +366,7 @@ export default defineComponent({
       this.view = { x, y, k, w, h };
       this.execute(
         new App.SetEditorViewParams(
-          this.ctx, this.editor.id, { ...this.view }
+          this.ctx, { ...this.view }
         )
       );
     }
@@ -383,7 +383,7 @@ export default defineComponent({
       // Configure view parameters
       this.execute(
         new App.SetEditorViewParams(
-          this.ctx, this.editor.id, { ...this.view }
+          this.ctx, { ...this.view }
         )
       );
     },

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/ClearPageRecoveryBank.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/ClearPageRecoveryBank.ts
@@ -1,0 +1,29 @@
+import { AppCommand } from "../AppCommand";
+import { ApplicationStore } from "@/store/StoreTypes";
+
+export class ClearPageRecoveryBank extends AppCommand {
+
+    /**
+     * Clears the application's page recovery bank.
+     * @param context
+     *  The application context.
+     */
+    constructor(context: ApplicationStore) {
+        super(context);
+    }
+
+
+    /**
+     * Executes the command.
+     */
+    public execute(): void {
+        for(let id of this._context.recoveryBank.pages.keys()) {
+            // Clear everything except the active page
+            if(id === this._context.activePage.id) {
+                continue;
+            }
+            this._context.recoveryBank.withdrawalEditor(id);
+        }
+    }
+
+}

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/ClearPageRecoveryBank.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/ClearPageRecoveryBank.ts
@@ -22,7 +22,7 @@ export class ClearPageRecoveryBank extends AppCommand {
             if(id === this._context.activePage.id) {
                 continue;
             }
-            this._context.recoveryBank.withdrawalEditor(id);
+            this._context.recoveryBank.withdrawEditor(id);
         }
     }
 

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
@@ -85,9 +85,6 @@ export class LoadFile extends AppCommand {
      * Executes the command.
      */
     public execute(): void {
-        // NOTE: For now, only one page will be loaded at a time.
-        this._context.pages.clear();
-        this._context.pages.set(this._editor.id, this._editor);
         this._context.activePage = this._editor;
     }
 

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/PublishPageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/PublishPageToDevice.ts
@@ -1,7 +1,6 @@
 import { AppCommand } from "../AppCommand";
 import { ApplicationStore } from "@/store/StoreTypes";
 import { Browser } from "@/assets/scripts/Browser";
-import { PageEditor } from "@/store/PageEditor";
 
 export class PublishPageToDevice extends AppCommand {
 
@@ -9,14 +8,12 @@ export class PublishPageToDevice extends AppCommand {
      * Publishes a page to the user's file system.
      * @param context
      *  The application context.
-     * @param id
-     *  The id of the page.
      */
-    constructor(context: ApplicationStore, id: string) {
+    constructor(context: ApplicationStore) {
         super(context);
         let editor = context.activePage;
         if(!editor.isValid()) {
-            throw new Error(`Page '${ id }' is not valid.`);
+            throw new Error(`Page '${ editor.id }' is not valid.`);
         } else if(!this._context.publisher) {
             throw new Error(`App is not configured with a publisher.`);
         }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/PublishPageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/PublishPageToDevice.ts
@@ -6,12 +6,6 @@ import { PageEditor } from "@/store/PageEditor";
 export class PublishPageToDevice extends AppCommand {
 
     /**
-     * The page's editor.
-     */
-    private _editor: PageEditor;
-
-
-    /**
      * Publishes a page to the user's file system.
      * @param context
      *  The application context.
@@ -20,15 +14,11 @@ export class PublishPageToDevice extends AppCommand {
      */
     constructor(context: ApplicationStore, id: string) {
         super(context);
-        let editor = context.pages.get(id);
-        if(!editor) {
-            throw new Error(`Page '${ id }' not found.`);
-        } else if(!editor.isValid()) {
+        let editor = context.activePage;
+        if(!editor.isValid()) {
             throw new Error(`Page '${ id }' is not valid.`);
         } else if(!this._context.publisher) {
             throw new Error(`App is not configured with a publisher.`);
-        } else {
-            this._editor = editor;
         }
     }
 
@@ -37,9 +27,10 @@ export class PublishPageToDevice extends AppCommand {
      * Executes the command.
      */
     public execute(): void {
+        let editor = this._context.activePage;
         Browser.downloadTextFile(
-            this._editor.page.props.toString(),
-            this._context.publisher!.publish(this._editor.page),
+            editor.page.props.toString(),
+            this._context.publisher!.publish(editor.page),
             "json"
         );
     }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageImageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageImageToDevice.ts
@@ -7,12 +7,6 @@ import { PageEditor } from "@/store/PageEditor";
 export class SavePageImageToDevice extends AppCommand {
 
     /**
-     * The page's editor.
-     */
-    private _editor: PageEditor;
-
-
-    /**
      * Saves a page as an image to the user's file system.
      * @param context
      *  The application context.
@@ -21,12 +15,6 @@ export class SavePageImageToDevice extends AppCommand {
      */
     constructor(context: ApplicationStore, id: string) {
         super(context);
-        let editor = context.pages.get(id);
-        if(!editor) {
-            throw new Error(`Page '${ id }' not found.`);
-        } else {
-            this._editor = editor;
-        }
     }
 
 
@@ -34,17 +22,18 @@ export class SavePageImageToDevice extends AppCommand {
      * Executes the command.
      */
     public execute(): void {
+        let editor = this._context.activePage;
         let d = this._context.settings.view.diagram;         
         let e = this._context.settings.file.image_export;
         let image = new PageImage(
-            this._editor.page,
+            editor.page,
             e.padding,
             d.display_grid,
             d.display_shadows,
             d.display_debug_mode
         );
         Browser.downloadImageFile(
-            this._editor.page.props.toString(),
+            editor.page.props.toString(),
             image.capture()
         );
     }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageImageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageImageToDevice.ts
@@ -2,7 +2,6 @@ import { AppCommand } from "../AppCommand";
 import { ApplicationStore } from "@/store/StoreTypes";
 import { Browser } from "@/assets/scripts/Browser";
 import { PageImage } from "@/assets/scripts/BlockDiagram/PageImage";
-import { PageEditor } from "@/store/PageEditor";
 
 export class SavePageImageToDevice extends AppCommand {
 
@@ -10,10 +9,8 @@ export class SavePageImageToDevice extends AppCommand {
      * Saves a page as an image to the user's file system.
      * @param context
      *  The application context.
-     * @param id
-     *  The id of the page.
      */
-    constructor(context: ApplicationStore, id: string) {
+    constructor(context: ApplicationStore) {
         super(context);
     }
 

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
@@ -2,7 +2,6 @@ import Configuration from "@/assets/builder.config";
 import { AppCommand } from "../AppCommand";
 import { ApplicationStore } from "@/store/StoreTypes";
 import { Browser } from "@/assets/scripts/Browser";
-import { PageEditor } from "@/store/PageEditor";
 
 export class SavePageToDevice extends AppCommand {
 
@@ -10,10 +9,8 @@ export class SavePageToDevice extends AppCommand {
      * Saves a page to the user's file system.
      * @param context
      *  The application context.
-     * @param id
-     *  The id of the page.
      */
-    constructor(context: ApplicationStore, id: string) {
+    constructor(context: ApplicationStore) {
         super(context);
     }
 

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
@@ -7,12 +7,6 @@ import { PageEditor } from "@/store/PageEditor";
 export class SavePageToDevice extends AppCommand {
 
     /**
-     * The page's editor.
-     */
-    private _editor: PageEditor;
-
-
-    /**
      * Saves a page to the user's file system.
      * @param context
      *  The application context.
@@ -21,12 +15,6 @@ export class SavePageToDevice extends AppCommand {
      */
     constructor(context: ApplicationStore, id: string) {
         super(context);
-        let editor = context.pages.get(id);
-        if(!editor) {
-            throw new Error(`Page '${ id }' not found.`);
-        } else {
-            this._editor = editor;
-        }
     }
 
 
@@ -34,9 +22,11 @@ export class SavePageToDevice extends AppCommand {
      * Executes the command.
      */
     public execute(): void {
+        let editor = this._context.activePage;
+        // Download page
         Browser.downloadTextFile(
-            this._editor.page.props.toString(),
-            this._editor.toFile(),
+            editor.page.props.toString(),
+            editor.toFile(),
             Configuration.file_type_extension
         );
     }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
@@ -29,6 +29,8 @@ export class SavePageToDevice extends AppCommand {
             editor.toFile(),
             Configuration.file_type_extension
         );
+        // Withdrawal progress from recovery bank
+        this._context.recoveryBank.withdrawalEditor(editor.id);
     }
 
 }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SavePageToDevice.ts
@@ -26,8 +26,8 @@ export class SavePageToDevice extends AppCommand {
             editor.toFile(),
             Configuration.file_type_extension
         );
-        // Withdrawal progress from recovery bank
-        this._context.recoveryBank.withdrawalEditor(editor.id);
+        // Withdraw progress from recovery bank
+        this._context.recoveryBank.withdrawEditor(editor.id);
     }
 
 }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SaveSelectionImageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SaveSelectionImageToDevice.ts
@@ -8,11 +8,6 @@ import { DiagramObjectModel } from "@/assets/scripts/BlockDiagram";
 export class SaveSelectionImageToDevice extends AppCommand {
 
     /**
-     * The page's editor.
-     */
-    private _editor: PageEditor;
-
-    /**
      * The objects to capture. 
      */
     private _objects: DiagramObjectModel[]
@@ -27,12 +22,7 @@ export class SaveSelectionImageToDevice extends AppCommand {
      */
     constructor(context: ApplicationStore, id: string) {
         super(context);
-        let editor = context.pages.get(id);
-        if(!editor) {
-            throw new Error(`Page '${ id }' not found.`);
-        } else {
-            this._editor = editor;
-        }
+        let editor = context.activePage;
         this._objects = [...editor.page.getSubtree(o => o.isSelected())];
     }
 
@@ -41,17 +31,18 @@ export class SaveSelectionImageToDevice extends AppCommand {
      * Executes the command.
      */
     public execute(): void {
+        let editor = this._context.activePage;
         let d = this._context.settings.view.diagram;         
         let e = this._context.settings.file.image_export;
         let image = new PageImage(
-            this._editor.page,
+            editor.page,
             e.padding,
             d.display_grid,
             d.display_shadows,
             d.display_debug_mode
         );
         Browser.downloadImageFile(
-            this._editor.page.props.toString(),
+            editor.page.props.toString(),
             image.capture(this._objects)
         );
     }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SaveSelectionImageToDevice.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SaveSelectionImageToDevice.ts
@@ -2,7 +2,6 @@ import { AppCommand } from "../AppCommand";
 import { ApplicationStore } from "@/store/StoreTypes";
 import { Browser } from "@/assets/scripts/Browser";
 import { PageImage } from "@/assets/scripts/BlockDiagram/PageImage";
-import { PageEditor } from "@/store/PageEditor";
 import { DiagramObjectModel } from "@/assets/scripts/BlockDiagram";
 
 export class SaveSelectionImageToDevice extends AppCommand {
@@ -17,10 +16,8 @@ export class SaveSelectionImageToDevice extends AppCommand {
      * Saves a page's selection as an image to the user's file system.
      * @param context
      *  The application context.
-     * @param id
-     *  The id of the page.
      */
-    constructor(context: ApplicationStore, id: string) {
+    constructor(context: ApplicationStore) {
         super(context);
         let editor = context.activePage;
         this._objects = [...editor.page.getSubtree(o => o.isSelected())];

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorPointerLocation.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorPointerLocation.ts
@@ -5,11 +5,6 @@ import { PageEditor } from "@/store/PageEditor";
 export class SetEditorPointerLocation extends AppCommand {
 
     /**
-     * The editor.
-     */
-    private _editor: PageEditor;
-
-    /**
      * The pointer's x location.
      */
     private _x: number;
@@ -33,12 +28,6 @@ export class SetEditorPointerLocation extends AppCommand {
      */
     constructor(context: ApplicationStore, id: string, x: number, y: number) {
         super(context);
-        let editor = context.pages.get(id);
-        if(!editor) {
-            throw new Error(`Page '${ id }' not found.`);
-        } else {
-            this._editor = editor;
-        }
         this._x = x;
         this._y = y;
     }
@@ -48,7 +37,7 @@ export class SetEditorPointerLocation extends AppCommand {
      * Executes the command.
      */
     public execute(): void {
-        this._editor.pointer.value = { x: this._x, y: this._y };
+        this._context.activePage.pointer.value = { x: this._x, y: this._y };
     }
 
 }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorPointerLocation.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorPointerLocation.ts
@@ -1,6 +1,5 @@
 import { AppCommand } from "../AppCommand";
 import { ApplicationStore } from "@/store/StoreTypes";
-import { PageEditor } from "@/store/PageEditor";
 
 export class SetEditorPointerLocation extends AppCommand {
 
@@ -19,14 +18,12 @@ export class SetEditorPointerLocation extends AppCommand {
      * Sets a page editor's pointer location.
      * @param context
      *  The application context.
-     * @param id
-     *  The id of the page.
      * @param x
      *  The pointer's x location.
      * @param y
      *  The pointer's y location.
      */
-    constructor(context: ApplicationStore, id: string, x: number, y: number) {
+    constructor(context: ApplicationStore, x: number, y: number) {
         super(context);
         this._x = x;
         this._y = y;

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorViewParams.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorViewParams.ts
@@ -1,6 +1,6 @@
 import { AppCommand } from "../AppCommand";
 import { ApplicationStore } from "@/store/StoreTypes";
-import { EditorViewParameters, PageEditor } from "@/store/PageEditor";
+import { EditorViewParameters } from "@/store/PageEditor";
 
 export class SetEditorViewParams extends AppCommand {
 
@@ -14,12 +14,10 @@ export class SetEditorViewParams extends AppCommand {
      * Sets a page editor's front-end view parameters.
      * @param context
      *  The application context.
-     * @param id
-     *  The id of the page.
      * @param params
      *  The new front-end view parameters.
      */
-    constructor(context: ApplicationStore, id: string, params: EditorViewParameters) {
+    constructor(context: ApplicationStore, params: EditorViewParameters) {
         super(context);
         this._params = params;
     }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorViewParams.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/SetEditorViewParams.ts
@@ -5,11 +5,6 @@ import { EditorViewParameters, PageEditor } from "@/store/PageEditor";
 export class SetEditorViewParams extends AppCommand {
 
     /**
-     * The editor.
-     */
-    private _editor: PageEditor;
-
-    /**
      * The new front-end view parameters.
      */
     private _params: EditorViewParameters;
@@ -26,12 +21,6 @@ export class SetEditorViewParams extends AppCommand {
      */
     constructor(context: ApplicationStore, id: string, params: EditorViewParameters) {
         super(context);
-        let editor = context.pages.get(id);
-        if(!editor) {
-            throw new Error(`Page '${ id }' not found.`);
-        } else {
-            this._editor = editor;
-        }
         this._params = params;
     }
 
@@ -40,7 +29,7 @@ export class SetEditorViewParams extends AppCommand {
      * Executes the command.
      */
     public execute(): void {
-        this._editor.view = this._params;
+        this._context.activePage.view = this._params;
     }
 
 }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/index.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/index.ts
@@ -1,3 +1,4 @@
+export * from "./ClearPageRecoveryBank";
 export * from "./CopySelectedChildren";
 export * from "./LoadFile";
 export * from "./LoadSettings";

--- a/src/attack_flow_builder/src/store/Commands/PageCommands/MoveCameraToObjects.ts
+++ b/src/attack_flow_builder/src/store/Commands/PageCommands/MoveCameraToObjects.ts
@@ -36,12 +36,7 @@ export class MoveCameraToObjects extends PageCommand {
                 `Objects must originate from the same root.`
             );
         }
-        let editor = context.pages.get(page.id);
-        if(!editor) {
-            throw new Error(
-                `Objects must be managed by an editor.`
-            );
-        }
+        let editor = context.activePage;
         super(page.id);
         this._editor = editor;
         // Calculate bounding box

--- a/src/attack_flow_builder/src/store/Commands/PageCommands/RedoPageCommand.ts
+++ b/src/attack_flow_builder/src/store/Commands/PageCommands/RedoPageCommand.ts
@@ -19,12 +19,7 @@ export class RedoPageCommand extends PageCommand {
      */
     constructor(context: ApplicationStore, page: string) {
         super(page);
-        let editor = context.pages.get(page);
-        if(editor) {
-            this._editor = editor;
-        } else {
-            throw new Error(`'${ page }' is not a page.`);
-        }
+        this._editor = context.activePage;
     }
 
 

--- a/src/attack_flow_builder/src/store/Commands/PageCommands/ResetCamera.ts
+++ b/src/attack_flow_builder/src/store/Commands/PageCommands/ResetCamera.ts
@@ -20,13 +20,7 @@ export class ResetCamera extends PageCommand {
      */
     constructor(context: ApplicationStore, page: PageModel) {
         super(page.id);
-        let editor = context.pages.get(page.id);
-        if(!editor) {
-            throw new Error(
-                `Page '${ page.id }' does not have an editor.`
-            );
-        }
-        this._editor = editor;
+        this._editor = context.activePage;
     }
     
     

--- a/src/attack_flow_builder/src/store/Commands/PageCommands/SpawnObject.ts
+++ b/src/attack_flow_builder/src/store/Commands/PageCommands/SpawnObject.ts
@@ -52,12 +52,7 @@ export class SpawnObject extends GroupCommand {
         y?: number
     ) {
         super();
-        let editor = context.pages.get(parent.root.id);
-        if(!editor) {
-            throw new Error(
-                `'${ parent.id }' must belong to an existing editor.`
-            );
-        }
+        let editor = context.activePage;
         // Create object
         let object = parent.factory.createObject(template);
         // Move object

--- a/src/attack_flow_builder/src/store/Commands/PageCommands/UndoPageCommand.ts
+++ b/src/attack_flow_builder/src/store/Commands/PageCommands/UndoPageCommand.ts
@@ -19,12 +19,7 @@ export class UndoPageCommand extends PageCommand {
      */
     constructor(context: ApplicationStore, page: string) {
         super(page);
-        let editor = context.pages.get(page);
-        if(editor) {
-            this._editor = editor;
-        } else {
-            throw new Error(`'${ page }' is not a page.`);
-        }
+        this._editor = context.activePage;
     }
     
 

--- a/src/attack_flow_builder/src/store/Commands/PageCommands/ZoomCamera.ts
+++ b/src/attack_flow_builder/src/store/Commands/PageCommands/ZoomCamera.ts
@@ -27,12 +27,7 @@ export class ZoomCamera extends PageCommand {
      */
     constructor(context: ApplicationStore, page: PageModel, delta: number) {
         super(page.id);
-        let editor = context.pages.get(page.id);
-        if(!editor) {
-            throw new Error(
-                `Page '${ page.id }' does not have an editor.`
-            );
-        }
+        let editor = context.activePage;
         this._editor = editor;
         let k = editor.view.k
         let x = ((editor.view.w / 2) - editor.view.x) / k;

--- a/src/attack_flow_builder/src/store/PageEditor.ts
+++ b/src/attack_flow_builder/src/store/PageEditor.ts
@@ -114,19 +114,23 @@ export class PageEditor {
      * Executes a page command.
      * @param command
      *  The command.
+     * @returns
+     *  True if the command was recorded, false otherwise.
      */
-    public execute(command: PageCommand) {
+    public execute(command: PageCommand): boolean {
         if(command.page !== this.page.id) {
             throw new Error(
                 "Command is not configured to operate on this page."
             );
         }
-        if(command.execute()) {
+        let record = command.execute();
+        if(record) {
             this._redoStack = [];
             this._undoStack.push(command);
         }
         this._validator?.run(this.page);
         this.trigger.value++;
+        return record;
     }
 
 

--- a/src/attack_flow_builder/src/store/PageRecoveryBank.ts
+++ b/src/attack_flow_builder/src/store/PageRecoveryBank.ts
@@ -52,14 +52,14 @@ export class PageRecoveryBank {
     }
 
     /**
-     * Withdrawals an editor from the bank.
+     * Withdraws an editor from the bank.
      * @param editor
-     *  The id of the page editor to withdrawal.
+     *  The id of the page editor to withdraw.
      */
-    public withdrawalEditor(id: string) {
+    public withdrawEditor(id: string) {
         let key = `${ PageRecoveryBank.PREFIX }${ id }`;
         if(localStorage.getItem(key) !== null) {
-            // Withdrawal page
+            // Withdraw page
             this.pages.delete(id);
             // Mirror to local storage
             localStorage.removeItem(key);

--- a/src/attack_flow_builder/src/store/PageRecoveryBank.ts
+++ b/src/attack_flow_builder/src/store/PageRecoveryBank.ts
@@ -1,0 +1,69 @@
+import { PageEditor } from "./PageEditor";
+
+export class PageRecoveryBank {
+
+    /**
+     * The recovery bank's local storage prefix.
+     */
+    private static PREFIX = "__recovery_bank_"
+
+
+    /**
+     * The recovered page list.
+     */
+    public pages: Map<string, { name: string, file: string }>;
+
+
+    /**
+     * Creates a {@link PageRecoveryBank}.
+     */
+    constructor() {
+        this.pages = new Map();
+        for(let i = 0; i < localStorage.length; i++) {
+            // Look up key
+            let key = localStorage.key(i)!;
+            if(!key.startsWith(PageRecoveryBank.PREFIX)) {
+                continue;
+            }
+            let value = JSON.parse(localStorage.getItem(key)!);
+            let id = key.substring(PageRecoveryBank.PREFIX.length);
+            this.pages.set(id, value);
+        }
+    }
+
+
+    /**
+     * Stores a page editor in the bank.
+     * @param editor
+     *  The page editor.
+     */
+    public storeEditor(editor: PageEditor) {
+        let pageDate = new Date().toLocaleString();
+        let pageTitle = editor.page.props.toString();
+        let key = `${ PageRecoveryBank.PREFIX }${ editor.id }`;
+        let value = {
+            name : `${ pageTitle } (${ pageDate })`,
+            file : editor.toFile()
+        };
+        // Store page
+        this.pages.set(editor.id, value);
+        // Mirror to local storage
+        localStorage.setItem(key, JSON.stringify(value));
+    }
+
+    /**
+     * Withdrawals an editor from the bank.
+     * @param editor
+     *  The id of the page editor to withdrawal.
+     */
+    public withdrawalEditor(id: string) {
+        let key = `${ PageRecoveryBank.PREFIX }${ id }`;
+        if(localStorage.getItem(key) !== null) {
+            // Withdrawal page
+            this.pages.delete(id);
+            // Mirror to local storage
+            localStorage.removeItem(key);
+        }
+    }
+
+}

--- a/src/attack_flow_builder/src/store/StoreTypes.ts
+++ b/src/attack_flow_builder/src/store/StoreTypes.ts
@@ -1,6 +1,7 @@
 import { PageEditor } from "@/store/PageEditor"
 import { DiagramValidator } from "@/assets/scripts/DiagramValidator/DiagramValidator"
 import { DiagramPublisher } from "@/assets/scripts/DiagramPublisher/DiagramPublisher"
+import { PageRecoveryBank } from "./PageRecoveryBank"
 import { BlockDiagramSchema } from "@/assets/scripts/BlockDiagram/DiagramFactory"
 import { DiagramObjectModel } from "@/assets/scripts/BlockDiagram"
 
@@ -27,8 +28,8 @@ export type ApplicationStore = {
     settings: AppSettings,
     clipboard: DiagramObjectModel[],
     publisher: DiagramPublisher | undefined,
-    pages: Map<string, PageEditor>,
-    activePage: PageEditor
+    activePage: PageEditor,
+    recoveryBank: PageRecoveryBank
 }
 
 /**

--- a/src/attack_flow_builder/src/store/Stores/ContextMenuStore.ts
+++ b/src/attack_flow_builder/src/store/Stores/ContextMenuStore.ts
@@ -165,19 +165,19 @@ export default {
                     {
                         text: "Save",
                         type: MenuType.Item,
-                        data: () => new App.SavePageToDevice(ctx, page.id),
+                        data: () => new App.SavePageToDevice(ctx),
                         shortcut: file.save_file
                     },
                     {
                         text: "Save as Image",
                         type: MenuType.Item,
-                        data: () => new App.SavePageImageToDevice(ctx, page.id),
+                        data: () => new App.SavePageImageToDevice(ctx),
                         shortcut: file.save_image
                     },
                     {
                         text: "Save Selection as Image",
                         type: MenuType.Item,
-                        data: () => new App.SaveSelectionImageToDevice(ctx, page.id),
+                        data: () => new App.SaveSelectionImageToDevice(ctx),
                         shortcut: file.save_select_image,
                         disabled: !rootGetters["ApplicationStore/hasSelection"],
                     }
@@ -208,7 +208,7 @@ export default {
                     {
                         text: `Publish ${ Configuration.file_type_name }`,
                         type: MenuType.Item,
-                        data: () => new App.PublishPageToDevice(ctx, page.id),
+                        data: () => new App.PublishPageToDevice(ctx),
                         shortcut: file.publish_file,
                         disabled: !rootGetters["ApplicationStore/isValid"]
                     }

--- a/src/attack_flow_builder/src/store/Stores/HotkeyStore.ts
+++ b/src/attack_flow_builder/src/store/Stores/HotkeyStore.ts
@@ -59,22 +59,22 @@ export default {
                     repeatable: false
                 },
                 {
-                    data: () => new App.SavePageToDevice(ctx, page.id),
+                    data: () => new App.SavePageToDevice(ctx),
                     shortcut: file.save_file,
                     repeatable: false
                 },
                 {
-                    data: () => new App.SavePageImageToDevice(ctx, page.id),
+                    data: () => new App.SavePageImageToDevice(ctx),
                     shortcut: file.save_image,
                     repeatable: false
                 },
                 {
-                    data: () => new App.SaveSelectionImageToDevice(ctx, page.id),
+                    data: () => new App.SaveSelectionImageToDevice(ctx),
                     shortcut: file.save_select_image,
                     repeatable: false
                 },
                 {
-                    data: () => new App.PublishPageToDevice(ctx, page.id),
+                    data: () => new App.PublishPageToDevice(ctx),
                     shortcut: file.publish_file,
                     repeatable: false,
                     disabled: !ctx.publisher || !isValid


### PR DESCRIPTION
### Overview

Implements basic autosave functionality.

![image](https://github.com/center-for-threat-informed-defense/attack-flow/assets/79934822/c29a7407-c3d2-437e-9c1f-cf60d8035b99)

The builder now logs all document edits to `localStorage`. If the builder closes with unsaved changes, the unsaved changes can be recovered via the _Open Recovered Files_ submenu. This menu is **only** visible when there exist documents with unsaved changes.

Simply click on a recovered file to begin editing it. Once saved, the recovered file will disappear from the _Open Recovered Files_ submenu.

You can also clear the recovered files list at any time by clicking _Delete Recovered Files_ under the _Open Recovered Files_ submenu.

### Implementation Notes

The original plan involved leveraging the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API). Unfortunately, the `FileSystemWritableFileStream` construct, required to write changes back to the file system, [is still not fully supported by all 5 of the major internet browsers](https://caniuse.com/?search=FileSystemWritableFileStream). In order to achieve the greatest level of compatibility, `localStorage` was chosen instead.

⚠ **IMPORTANT:**

Accessing the application from a webserver will not present issues for autosave. The same cannot be said when opening the application locally via the compiled `index.html` file. In this case, the behavior of `localStorage` varies from browser to browser.

[Per Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage):

> For documents loaded from `file:` URLs (that is, files opened in the browser directly from the user's local filesystem, rather than being served from a web server) the requirements for `localStorage` behavior are undefined and may vary among different browsers.

> In all current browsers, `localStorage` seems to return a different object for each `file:` URL. In other words, each `file:` URL seems to have its own unique local-storage area. But there are no guarantees about that behavior, so you shouldn't rely on it because, as mentioned above, the requirements for `file:` URLs remain undefined. So it's possible that browsers may change their `file:` URL handling for `localStorage` at any time. In fact some browsers have changed their handling for it over time.
