### PR TITLE
AF-127 Text Trimming

### DIFF
--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -90,8 +90,6 @@ class AttackFlowPublisher extends DiagramPublisher {
     public override publish(diagram: DiagramObjectModel): string {
         let graph = SemanticAnalyzer.toGraph(diagram);
 
-        console.log("PUBLISHING");
-
         // Extract page
         let pageId = diagram.id;
         let page = graph.nodes.get(pageId);
@@ -189,10 +187,6 @@ class AttackFlowPublisher extends DiagramPublisher {
      *  The action's properties.
      */
     private mergeActionProperty(node: Sdo, property: DictionaryProperty) {
-
-        console.log("ACTION PROPERTY");
-        console.log(property);
-
         for(let [key, prop] of property.value) {
             switch(key) {
                 case "confidence":
@@ -216,7 +210,6 @@ class AttackFlowPublisher extends DiagramPublisher {
 
             // Remove trailing whitespace on StringProperties
             if (prop instanceof StringProperty && prop.isDefined()) {
-                console.log("DEFINED STRING ACT");
                 node[key] = prop.toString().trim();
             }
         }
@@ -230,10 +223,6 @@ class AttackFlowPublisher extends DiagramPublisher {
      *  The dictionary property.
      */
     private mergeBasicDictProperty(node: Sdo, property: DictionaryProperty) {
-
-        console.log("DICT PROPERTY");
-        console.log(property);
-
         for(let [key, prop] of property.value) {
             switch(prop.type) {
                 case PropertyType.Dictionary:
@@ -251,7 +240,6 @@ class AttackFlowPublisher extends DiagramPublisher {
                     break;
                 case PropertyType.String:
                     if (prop.isDefined()) {
-                        console.log("DEFINED STRING DICT");
                         node[key] = prop.toString().trim();
                     }
                     break;

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -816,7 +816,7 @@ class AttackFlowPublisher extends DiagramPublisher {
                         break;
                     default:
                         if(prop.isDefined()) {
-                            author[key] = prop.toRawValue()
+                            author[key] = prop.toString().trim();
                         }
                         break;
                 }

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -238,7 +238,7 @@ class AttackFlowPublisher extends DiagramPublisher {
                         this.mergeBasicListProperty(node, key, prop as ListProperty);
                     }
                     break;
-                case PropertyType.String:
+                case PropertyType.String: // Remove trailing whitespace on StringProperties
                     if (prop.isDefined()) {
                         node[key] = prop.toString().trim();
                     }
@@ -271,6 +271,11 @@ class AttackFlowPublisher extends DiagramPublisher {
                     throw new Error("Basic lists cannot contain lists.");
                 case PropertyType.Enum:
                     throw new Error("Basic lists cannot contain enums.");
+                case PropertyType.String: // Remove trailing whitespace on StringProperties
+                    if(prop.isDefined()) {
+                        node[key].push(prop.toString().trim());
+                    }
+                    break;
                 default:
                     if(prop.isDefined()) {
                         node[key].push(prop.toRawValue());

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -11,7 +11,8 @@ import {
     Property,
     PropertyType,
     RawEntries,
-    SemanticAnalyzer
+    SemanticAnalyzer,
+    StringProperty
 } from "./scripts/BlockDiagram";
 
 
@@ -88,6 +89,8 @@ class AttackFlowPublisher extends DiagramPublisher {
      */
     public override publish(diagram: DiagramObjectModel): string {
         let graph = SemanticAnalyzer.toGraph(diagram);
+
+        console.log("PUBLISHING");
 
         // Extract page
         let pageId = diagram.id;
@@ -186,6 +189,10 @@ class AttackFlowPublisher extends DiagramPublisher {
      *  The action's properties.
      */
     private mergeActionProperty(node: Sdo, property: DictionaryProperty) {
+
+        console.log("ACTION PROPERTY");
+        console.log(property);
+
         for(let [key, prop] of property.value) {
             switch(key) {
                 case "confidence":
@@ -206,6 +213,12 @@ class AttackFlowPublisher extends DiagramPublisher {
                         node[key] = prop.toRawValue();
                     }
             }
+
+            // Remove trailing whitespace on StringProperties
+            if (prop instanceof StringProperty && prop.isDefined()) {
+                console.log("DEFINED STRING ACT");
+                node[key] = prop.toString().trim();
+            }
         }
     }
 
@@ -217,6 +230,10 @@ class AttackFlowPublisher extends DiagramPublisher {
      *  The dictionary property.
      */
     private mergeBasicDictProperty(node: Sdo, property: DictionaryProperty) {
+
+        console.log("DICT PROPERTY");
+        console.log(property);
+
         for(let [key, prop] of property.value) {
             switch(prop.type) {
                 case PropertyType.Dictionary:
@@ -230,6 +247,12 @@ class AttackFlowPublisher extends DiagramPublisher {
                 case PropertyType.List:
                     if (prop.isDefined()) {
                         this.mergeBasicListProperty(node, key, prop as ListProperty);
+                    }
+                    break;
+                case PropertyType.String:
+                    if (prop.isDefined()) {
+                        console.log("DEFINED STRING DICT");
+                        node[key] = prop.toString().trim();
                     }
                     break;
                 default:
@@ -788,6 +811,7 @@ class AttackFlowPublisher extends DiagramPublisher {
                         author[key] = prop
                             .toReferenceValue()!
                             .toString()
+                            .trim()
                             .toLocaleLowerCase();
                         break;
                     default:

--- a/src/attack_flow_builder/src/assets/builder.config.publisher.ts
+++ b/src/attack_flow_builder/src/assets/builder.config.publisher.ts
@@ -675,6 +675,7 @@ class AttackFlowPublisher extends DiagramPublisher {
                     flow[key] = prop
                         .toReferenceValue()!
                         .toString()
+                        .trim()
                         .toLocaleLowerCase();
                     break;
                 default:


### PR DESCRIPTION
Currently trims leading and trailing whitespace via _.trim()_. I see there is a future ticket (AF-170) to handle single vs multi-line text fields. Should I strip all newline characters for now, or in the future will the UI prevent users from creating new lines (i.e. hitting enter) inside of single-line text fields?

Still testing to verify I hit all spots where we're looking to trim, marking as draft for now.