### PR TITLE
AF-180: Account for Device Pixel Ratio when Rendering Graphics

### DIFF
--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/DiagramElement/RasterCache.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/DiagramElement/RasterCache.ts
@@ -20,7 +20,7 @@ export class RasterCache {
      * Creates a new {@link RasterCache}.
      */
     constructor() {
-        this._scale = 1;
+        this._scale = window.devicePixelRatio;
         this._cache = new Map();
     }
 
@@ -74,7 +74,7 @@ export class RasterCache {
      *  The new scale value.
      */
     public setScale(scale: number) {
-        this._scale = scale;
+        this._scale = scale * window.devicePixelRatio;
         this._cache.clear();
     }
 
@@ -84,7 +84,7 @@ export class RasterCache {
      *  The cache's current scale.
      */
     public getScale(): number {
-        return this._scale;
+        return this._scale / window.devicePixelRatio;
     }
 
 }

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Utilities/Canvas.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Utilities/Canvas.ts
@@ -1,0 +1,77 @@
+/**
+ * Resizes a canvas context according to the current screen's pixel ratio.
+ * @param context
+ *  The context to resize.
+ * @param width
+ *  The new width of the context.
+ * @param height
+ *  The new height of the context.
+ */
+export function resizeContext(
+    context: CanvasRenderingContext2D,
+    width: number,
+    height: number
+) {
+    context.canvas.width = width * window.devicePixelRatio;
+    context.canvas.height = height * window.devicePixelRatio;
+    context.canvas.style.width = `${ width }px`;
+    context.canvas.style.height = `${ height }px`;
+    context.scale(window.devicePixelRatio, window.devicePixelRatio);
+}
+
+/**
+ * Transforms a canvas context according to the current screen's pixel ratio.
+ * @param context
+ *  The context to resize.
+ * @param k
+ *  The context's scale.
+ * @param x
+ *  The context's x translation.
+ * @param y
+ *  The context's y translation.
+ */
+export function transformContext(
+    context: CanvasRenderingContext2D,
+    k: number,
+    x: number,
+    y: number
+) {
+    k *= window.devicePixelRatio,
+    x *= window.devicePixelRatio,
+    y *= window.devicePixelRatio;
+    context.setTransform(
+        k, 0, 0,
+        k, x, y
+    );
+}
+
+/**
+ * Resizes and transforms a canvas context according to the current screen's
+ * pixel ratio.
+ * @param context
+ *  The context to resize.
+ * @param width
+ *  The new width of the context.
+ * @param height
+ *  The new height of the context.
+ * @param k
+ *  The context's scale.
+ * @param x
+ *  The context's x translation.
+ * @param y
+ *  The context's y translation.
+ */
+export function resizeAndTransformContext(
+    context: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    k: number,
+    x: number,
+    y: number
+) {
+    context.canvas.width = width * window.devicePixelRatio;
+    context.canvas.height = height * window.devicePixelRatio;
+    context.canvas.style.width = `${ width }px`;
+    context.canvas.style.height = `${ height }px`;
+    transformContext(context, k, x, y);
+}


### PR DESCRIPTION
## Overview

Sharpens graphics on monitors with high pixel density (like Apple Retina displays).

###  Shaper Graphics

This PR updates `BlockDiagram` so that it accounts for the device's current pixel ratio.

This PR also introduces the `"dppx-change"` event to the `Browser` utility class. Now, developers can subscribe to changes to the device's pixel ratio. (This usually occurs when dragging the browser to and from monitors with different pixel densities.) This new event is used by `BlockDiagram` to re-render the chart in such cases.