### PR TITLE
AF-155 (Fix): Reassign Grid Hotkey

### DIFF
--- a/src/attack_flow_builder/public/settings_macos.json
+++ b/src/attack_flow_builder/public/settings_macos.json
@@ -57,7 +57,7 @@
             "close_group": ""
         },
         "view": {
-            "toggle_grid": "Alt+G",
+            "toggle_grid": "Control+G",
             "toggle_shadows": "",
             "reset_view": "Escape",
             "zoom_in": "",

--- a/src/attack_flow_builder/public/settings_macos.json
+++ b/src/attack_flow_builder/public/settings_macos.json
@@ -57,7 +57,7 @@
             "close_group": ""
         },
         "view": {
-            "toggle_grid": "Control+G",
+            "toggle_grid": "Control+Shift+G",
             "toggle_shadows": "",
             "reset_view": "Escape",
             "zoom_in": "",


### PR DESCRIPTION
## Overview
Reassigns the "Display Grid" hotkey from `Alt+G` to `Control+Shift+G`