### PR TITLE
Allow same-origin credentials for loading flow files

### DIFF
--- a/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
@@ -76,7 +76,7 @@ export class LoadFile extends AppCommand {
      *  A Promise that resolves with the {@link LoadFile} command.
      */
     public static async fromUrl(context: ApplicationStore, url: string): Promise<LoadFile> {
-        let file = await (await fetch(url, { credentials: "include" })).text();
+        let file = await (await fetch(url)).text();
         let page = await PageEditor.fromFile(file);
         return new LoadFile(context, page);
     }

--- a/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
+++ b/src/attack_flow_builder/src/store/Commands/AppCommands/LoadFile.ts
@@ -76,7 +76,7 @@ export class LoadFile extends AppCommand {
      *  A Promise that resolves with the {@link LoadFile} command.
      */
     public static async fromUrl(context: ApplicationStore, url: string): Promise<LoadFile> {
-        let file = await (await fetch(url, { credentials: "omit" })).text();
+        let file = await (await fetch(url, { credentials: "include" })).text();
         let page = await PageEditor.fromFile(file);
         return new LoadFile(context, page);
     }


### PR DESCRIPTION
We host our own Builder and credentials are required to access the site. Our instance of Builder has a local folder of `.afb` files inside the web root. This allows us to send authorised users direct links to flows, like this:

`https://builder-site.com/?src=flows/flow1.afb`

... while ensuring the site and the flow files are protected.

However, this doesn't work using the current version. The reason for this is it is not sending the site's cookies to flow files defined as the `src` URL parameter. This is due to the specific `omit` flag in the `fromUrl` function.

This PR makes one small change to remove the `omit` flag to fetch, and let it use its default behaviour of sending credentials for same-origin requests.

I am not a Javascript expert, so I apologise if I am making some obvious mistakes here.

Thanks so much for all the work you do at MITRE, we really appreciate the great resources you share with the world.

[Documentation on fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch)