### PR TITLE
AF-69: rename field placeholders from 'null' to 'none'

### DIFF
--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/DateProperty.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/DateProperty.ts
@@ -103,7 +103,7 @@ export class DateProperty extends Property {
      *  The property as a string.
      */
     public toString(): string {
-        return `${ this._value ?? 'Null' }`;
+        return `${ this._value ?? 'None' }`;
     }
 
 }

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/EnumProperty.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/EnumProperty.ts
@@ -137,7 +137,7 @@ export class EnumProperty extends Property {
      *  The property as a string.
      */
     public toString(): string {
-        return this.toReferenceValue()?.toString() ?? "Null";
+        return this.toReferenceValue()?.toString() ?? "None";
     }
 
 }

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/NumberProperty.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/NumberProperty.ts
@@ -121,7 +121,7 @@ export class NumberProperty extends Property {
      *  The property as a string.
      */
     public toString(): string {
-        return `${ this._value ?? 'Null' }`;
+        return `${ this._value ?? 'None' }`;
     }
 
 }

--- a/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/StringProperty.ts
+++ b/src/attack_flow_builder/src/assets/scripts/BlockDiagram/Property/StringProperty.ts
@@ -100,7 +100,7 @@ export class StringProperty extends Property {
      *  The property as a string.
      */
     public toString(): string {
-        return this._value ?? "Null";
+        return this._value ?? "None";
     }
 
 }

--- a/src/attack_flow_builder/src/components/Controls/Fields/DateTimeField.vue
+++ b/src/attack_flow_builder/src/components/Controls/Fields/DateTimeField.vue
@@ -3,7 +3,7 @@
     <div class="grid-container">
       <div class="value" v-show="!showEditor">
         <p v-if="value === null" class="null-value">
-          Null
+          None
         </p>
         <p v-else class="date-value">
           {{ prop_M }} {{ prop_D }}, {{ prop_Y }}
@@ -140,7 +140,7 @@ export default defineComponent({
      */
     prop_M(): string {
       let v = this.value;
-      return v ? Months[v.getUTCMonth()] : "Null";
+      return v ? Months[v.getUTCMonth()] : "None";
     },
 
     /**
@@ -150,7 +150,7 @@ export default defineComponent({
      */
     prop_D(): string {
       let v = this.value;
-      return `${ v?.getUTCDate() ?? 'Null' }`;
+      return `${ v?.getUTCDate() ?? 'None' }`;
     },
     
     /**
@@ -160,7 +160,7 @@ export default defineComponent({
      */
     prop_Y(): string {
       let v = this.value;
-      return `${ v?.getUTCFullYear() ?? 'Null' }`;
+      return `${ v?.getUTCFullYear() ?? 'None' }`;
     },
 
     /**
@@ -170,7 +170,7 @@ export default defineComponent({
      */
     prop_H(): string {
       let v = this.value;
-      return v ? `${ v.getUTCHours() }`.padStart(2, '0') : "Null";
+      return v ? `${ v.getUTCHours() }`.padStart(2, '0') : "None";
     },
 
     /**
@@ -180,7 +180,7 @@ export default defineComponent({
      */
     prop_m(): string {
       let v = this.value;
-      return v ? `${ v.getUTCMinutes() }`.padStart(2, '0') : "Null";
+      return v ? `${ v.getUTCMinutes() }`.padStart(2, '0') : "None";
     },
 
     /**
@@ -190,7 +190,7 @@ export default defineComponent({
      */
     prop_s(): string {
       let v = this.value;
-      return v ? `${ v.getUTCSeconds() }`.padStart(2, '0') : "Null";
+      return v ? `${ v.getUTCSeconds() }`.padStart(2, '0') : "None";
     }
 
   },

--- a/src/attack_flow_builder/src/components/Controls/Fields/EnumField.vue
+++ b/src/attack_flow_builder/src/components/Controls/Fields/EnumField.vue
@@ -118,7 +118,7 @@ export default defineComponent({
     options(): { value: string | null, text: string }[] {
       let options: { value: string | null, text: string }[] = [];
       if(this.searchTerm === "") {
-        options.push({ value: null, text: "Null" });
+        options.push({ value: null, text: "None" });
       }
       let st = this.searchTerm.toLocaleLowerCase();
       for(let [value, prop] of this._property.options.value) {
@@ -140,7 +140,7 @@ export default defineComponent({
         let prop = this._property.options.value.get(this.select)!;
         return prop.toString();
       } else {
-        return "Null";
+        return "None";
       }
     },
 

--- a/src/attack_flow_builder/src/components/Controls/Fields/NumberField.vue
+++ b/src/attack_flow_builder/src/components/Controls/Fields/NumberField.vue
@@ -4,7 +4,7 @@
       v-model="value"
       type="text"
       ref="field"
-      placeholder="Null"
+      placeholder="None"
       @input="onInput"
       @keydown="onKeyDown"
       @blur="onBlur"

--- a/src/attack_flow_builder/src/components/Controls/Fields/TextField.vue
+++ b/src/attack_flow_builder/src/components/Controls/Fields/TextField.vue
@@ -20,7 +20,7 @@
       <textarea
         v-model="value"
         ref="field"
-        placeholder="Null"
+        placeholder="None"
         @input="onInput"
         @keyup.stop=""
         @keydown.stop="onKeyDown"


### PR DESCRIPTION
Renames text from 'Null' to 'None for the following fields:

- Date
- Enum
- Number
- Text/String
- Dictionary fields when primary key is empty (calls primary keys `toString` method)