### PR TITLE
create graphviz edge between attack-action and process

### DIFF
--- a/src/attack_flow/graphviz.py
+++ b/src/attack_flow/graphviz.py
@@ -43,7 +43,7 @@ def convert_attack_flow(bundle):
                 gv.edge(o.id, ref, "asset")
             for ref in o.get("effect_refs", []):
                 gv.edge(o.id, ref, "effect")
-            if (ref := o.get("command_ref", None)) is not None:
+            if ref := o.get("command_ref"):
                 gv.edge(o.id, ref, "command")
         elif o.type == "attack-asset":
             gv.node(o.id, _get_asset_label(o), shape="plaintext")

--- a/src/attack_flow/mermaid.py
+++ b/src/attack_flow/mermaid.py
@@ -52,7 +52,7 @@ class MermaidGraph:
                 shape_end = "))"
             elif self.classes[node_class][0] == "trap":
                 shape_start = "[/"
-                shape_end = "\\]"
+                shape_end = "\]"
             else:
                 shape_start = "["
                 shape_end = "]"
@@ -103,7 +103,7 @@ def convert_attack_flow(bundle):
                 graph.add_edge(o.id, ref, "asset")
             for ref in o.get("effect_refs", []):
                 graph.add_edge(o.id, ref, "effect")
-            if (ref := o.get("command_ref", None)) is not None:
+            if ref := o.get("command_ref"):
                 graph.add_edge(o.id, ref, "command")
         elif o.type == "attack-condition":
             graph.add_node(o.id, "condition", f"<b>Condition:</b> {o.description}")


### PR DESCRIPTION
According to the [attack-flow documentatino](https://center-for-threat-informed-defense.github.io/attack-flow/language/#attack-action) is the `command_ref` field a link to an identifier of type `process`. When creating an Attack Flow in the Builder, this field is correctly set. However, when generating an image from the JSON via graphviz, this field is not considered