### PR TITLE
Include sub-techniques in auto-filtering

### DIFF
--- a/src/attack_flow_builder/src/assets/scripts/OpenChart/DiagramModel/DiagramObject/Property/CollectionProperty/TupleProperty/CombinationIndex.ts
+++ b/src/attack_flow_builder/src/assets/scripts/OpenChart/DiagramModel/DiagramObject/Property/CollectionProperty/TupleProperty/CombinationIndex.ts
@@ -90,7 +90,10 @@ export class CombinationIndex {
             // Add relationships to results matrix
             const valueIdx = this.values.get(valueId)!;
             for (const rel of this.lookup[valueIdx]) {
-                const [prop, value] = idxToId[rel].split(/\./g);
+                const id = idxToId[rel];
+                const splitIdx = id.indexOf(".");
+                const prop = id.substring(0, splitIdx);
+                const value = id.substring(splitIdx + 1);
                 matrix.get(prop)![i].add(value);
             }
             i++;


### PR DESCRIPTION
TTP Mapping will automatically sort relevant TTPs when you select a tactic. However, that sorting is missing sub techniques.

As an example, here is a screenshot from the [public ATT&CK Flow Builder instance](https://center-for-threat-informed-defense.github.io/attack-flow/ui).

<img width="350" height="410" alt="image" src="https://github.com/user-attachments/assets/ec64c01d-6ce5-4014-b3a2-b396b4761937" />

Here is an example from a build running within this PR:

<img width="350" height="410" alt="image" src="https://github.com/user-attachments/assets/7f0eb1a1-8e87-4b3e-b148-5de251027608" />
